### PR TITLE
Add filtering for results table

### DIFF
--- a/index.html
+++ b/index.html
@@ -160,6 +160,17 @@ button {
   box-shadow: 0 4px 12px rgba(123, 123, 124, 0.3);
 }
 .search-button:disabled { background-color: #A5B4FC; cursor: not-allowed; }
+.filter-button {
+  background-color: var(--primary-color);
+  color: white;
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: var(--border-radius-md);
+  cursor: pointer;
+}
+.filter-button:hover {
+  background-color: var(--primary-color-dark);
+}
 .file-button, .instructions-button {
   background-color: #F3F4F6;
   color: var(--text-color-primary);
@@ -312,6 +323,13 @@ STYLES FOR DYNAMICALLY GENERATED RESULTS
           <option value="10">10</option>
           <option value="20">20</option>
         </select>
+      </div>
+      <div class="form-group">
+        <label for="fileFilterSelect">Filter by file:</label>
+        <select id="fileFilterSelect">
+          <option value="all" selected>All Files</option>
+        </select>
+        <button id="missingButton" class="filter-button" type="button">Show Missing Files</button>
       </div>
 
       <div class="result-title">Result:</div>

--- a/script.js
+++ b/script.js
@@ -30,6 +30,19 @@ let currentPage = 1;
 let itemsPerPage = 5;
 let lastFoundKey = '';
 let lastFoundFile = '';
+let selectedFile = 'all';
+let showMissingOnly = false;
+
+function getFilteredResults() {
+  let results = currentResults;
+  if (selectedFile !== 'all') {
+    results = results.filter(r => r.file === selectedFile);
+  }
+  if (showMissingOnly) {
+    results = results.filter(r => r.value === 'Missing ❌');
+  }
+  return results;
+}
 
 function getLanguageFromFilename(filename) {
   const match = filename.match(/([a-z]{2}(-[A-Z]{2})?)\.json$/i);
@@ -216,7 +229,9 @@ function showResults(foundKey, searchValue, foundFile, allFiles) {
 
   
   const select = document.getElementById("itemsPerPageSelect");
-  itemsPerPage = parseInt(select.value) || 5; 
+  const fileSelect = document.getElementById("fileFilterSelect");
+  const missingButton = document.getElementById("missingButton");
+  itemsPerPage = parseInt(select.value) || 5;
   
   // Build the results data
   currentResults = [];
@@ -249,12 +264,23 @@ function showResults(foundKey, searchValue, foundFile, allFiles) {
       });
     }
   }
-  
+
+  fileSelect.innerHTML = '<option value="all">All Files</option>';
+  for (const fileData of allFiles) {
+    const option = document.createElement('option');
+    option.value = fileData.name;
+    option.textContent = fileData.name;
+    fileSelect.appendChild(option);
+  }
+  selectedFile = 'all';
+  showMissingOnly = false;
+  missingButton.textContent = 'Show Missing Files';
+
   // Reset to first page
   currentPage = 1;
-  
+
   // Show results with pagination
-  displayResultsPage(foundKey, foundFile);
+  displayResultsPage();
 }
 
 function displayResultsPage() {
@@ -262,11 +288,13 @@ function displayResultsPage() {
   const foundFile = lastFoundFile;
   const resultsContainer = document.getElementById("results-container");
   
+  const filteredResults = getFilteredResults();
+
   // Calculate pagination
-  const totalPages = Math.ceil(currentResults.length / itemsPerPage);
+  const totalPages = Math.ceil(filteredResults.length / itemsPerPage);
   const startIndex = (currentPage - 1) * itemsPerPage;
   const endIndex = startIndex + itemsPerPage;
-  const pageResults = currentResults.slice(startIndex, endIndex);
+  const pageResults = filteredResults.slice(startIndex, endIndex);
   
   // Build table rows for current page
   let tableRows = "";
@@ -303,7 +331,7 @@ function displayResultsPage() {
     paginationControls = `
       <div class="pagination-container">
         <div class="pagination-info">
-          Showing ${startIndex + 1}-${Math.min(endIndex, currentResults.length)} of ${currentResults.length} results
+          Showing ${startIndex + 1}-${Math.min(endIndex, filteredResults.length)} of ${filteredResults.length} results
         </div>
         <div class="pagination-controls">
           <button class="pagination-btn" onclick="previousPage()" ${currentPage === 1 ? 'disabled' : ''}>
@@ -351,7 +379,7 @@ function goToPage(page) {
 }
 
 function nextPage() {
-  const totalPages = Math.ceil(currentResults.length / itemsPerPage);
+  const totalPages = Math.ceil(getFilteredResults().length / itemsPerPage);
   if (currentPage < totalPages) {
     currentPage++;
     displayResultsPage(); // We need to store these values
@@ -377,13 +405,32 @@ function readFile(file) {
 
 document.addEventListener("DOMContentLoaded", () => {
   const select = document.getElementById("itemsPerPageSelect");
+  const fileSelect = document.getElementById("fileFilterSelect");
+  const missingButton = document.getElementById("missingButton");
 
   select.addEventListener("change", () => {
     itemsPerPage = parseInt(select.value) || 5;
 
     if (currentResults.length > 0) {
       currentPage = 1;
-      displayResultsPage(lastFoundKey, lastFoundFile);
+      displayResultsPage();
+    }
+  });
+
+  fileSelect.addEventListener("change", () => {
+    selectedFile = fileSelect.value;
+    if (currentResults.length > 0) {
+      currentPage = 1;
+      displayResultsPage();
+    }
+  });
+
+  missingButton.addEventListener("click", () => {
+    showMissingOnly = !showMissingOnly;
+    missingButton.textContent = showMissingOnly ? "Show All Files" : "Show Missing Files";
+    if (currentResults.length > 0) {
+      currentPage = 1;
+      displayResultsPage();
     }
   });
 });


### PR DESCRIPTION
## Summary
- add dropdown for selecting files
- add toggle button to show only missing translations
- filter results table based on user selections

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68761b098a9883248edd6b9a43f57fd6