### PR TITLE
Add file filter controls for translation results

### DIFF
--- a/index.html
+++ b/index.html
@@ -170,6 +170,19 @@ button {
   box-shadow: 0 4px 12px rgba(123, 123, 124, 0.3);
   background-color: #E5E7EB;
  }
+.filter-button {
+  background-color: var(--primary-color);
+  color: white;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: var(--border-radius-md);
+  margin-left: 0.5rem;
+  cursor: pointer;
+}
+.filter-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
 
 .tool-header-row { 
   display: flex;
@@ -312,6 +325,15 @@ STYLES FOR DYNAMICALLY GENERATED RESULTS
           <option value="10">10</option>
           <option value="20">20</option>
         </select>
+      </div>
+      <div class="form-group" id="filter-controls" style="display:none;">
+        <label for="fileFilterSelect">Filter by file:</label>
+        <select id="fileFilterSelect">
+          <option value="all" selected>All Files</option>
+        </select>
+        <button class="filter-button" id="missingFilterButton" onclick="toggleMissingFilter()" disabled>
+          Show Missing Files
+        </button>
       </div>
 
       <div class="result-title">Result:</div>

--- a/script.js
+++ b/script.js
@@ -26,6 +26,9 @@ const languageMap = {
 // Global variables
 let loadedFiles = [];
 let currentResults = [];
+let allResults = [];
+let selectedFile = "all";
+let showOnlyMissing = false;
 let currentPage = 1;
 let itemsPerPage = 5;
 let lastFoundKey = '';
@@ -210,6 +213,9 @@ async function findKey() {
 
 function showResults(foundKey, searchValue, foundFile, allFiles) {
   const resultsContainer = document.getElementById("results-container");
+  const fileSelect = document.getElementById("fileFilterSelect");
+  const filterControls = document.getElementById("filter-controls");
+  const missingBtn = document.getElementById("missingFilterButton");
 
   lastFoundKey = foundKey;
   lastFoundFile = foundFile;
@@ -219,22 +225,22 @@ function showResults(foundKey, searchValue, foundFile, allFiles) {
   itemsPerPage = parseInt(select.value) || 5; 
   
   // Build the results data
-  currentResults = [];
-  
+  allResults = [];
+
   for (const fileData of allFiles) {
     try {
       if (foundKey in fileData.content) {
         const language = getLanguageFromFilename(fileData.name);
         const value = fileData.content[foundKey];
         
-        currentResults.push({
+        allResults.push({
           file: fileData.name,
           value: value,
           language: language
         });
       }else{
           const language = getLanguageFromFilename(fileData.name);
-          currentResults.push({
+          allResults.push({
           file: fileData.name,
           value: "Missing ❌",
           language: language,
@@ -242,17 +248,37 @@ function showResults(foundKey, searchValue, foundFile, allFiles) {
       }
     } catch (err) {
       console.error(`Error processing ${fileData.name}:`, err);
-      currentResults.push({
+      allResults.push({
         file: fileData.name,
         value: "Missing ❌ error",
         language: "Missing ❌ error",
       });
     }
   }
-  
+
   // Reset to first page
   currentPage = 1;
-  
+
+  // Populate file dropdown options
+  if (fileSelect) {
+    fileSelect.innerHTML = '<option value="all">All Files</option>' +
+      allResults.map(r => r.file)
+               .filter((v, i, a) => a.indexOf(v) === i)
+               .map(f => `<option value="${f}">${f}</option>`)
+               .join('');
+    fileSelect.value = 'all';
+  }
+  if (filterControls) filterControls.style.display = 'block';
+  if (missingBtn) {
+    missingBtn.disabled = false;
+    missingBtn.textContent = 'Show Missing Files';
+  }
+
+  // Reset filters
+  selectedFile = 'all';
+  showOnlyMissing = false;
+  currentResults = allResults.slice();
+
   // Show results with pagination
   displayResultsPage(foundKey, foundFile);
 }
@@ -350,6 +376,31 @@ function goToPage(page) {
   displayResultsPage(); // We need to store these values
 }
 
+function applyFilters() {
+  let filtered = allResults.slice();
+
+  if (selectedFile !== 'all') {
+    filtered = filtered.filter(item => item.file === selectedFile);
+  }
+
+  if (showOnlyMissing) {
+    filtered = filtered.filter(item => item.value === 'Missing ❌');
+  }
+
+  currentResults = filtered;
+  currentPage = 1;
+  displayResultsPage();
+}
+
+function toggleMissingFilter() {
+  showOnlyMissing = !showOnlyMissing;
+  const btn = document.getElementById('missingFilterButton');
+  if (btn) {
+    btn.textContent = showOnlyMissing ? 'Show All' : 'Show Missing Files';
+  }
+  applyFilters();
+}
+
 function nextPage() {
   const totalPages = Math.ceil(currentResults.length / itemsPerPage);
   if (currentPage < totalPages) {
@@ -377,15 +428,28 @@ function readFile(file) {
 
 document.addEventListener("DOMContentLoaded", () => {
   const select = document.getElementById("itemsPerPageSelect");
+  const fileSelect = document.getElementById("fileFilterSelect");
+  const missingBtn = document.getElementById("missingFilterButton");
 
   select.addEventListener("change", () => {
     itemsPerPage = parseInt(select.value) || 5;
 
     if (currentResults.length > 0) {
       currentPage = 1;
-      displayResultsPage(lastFoundKey, lastFoundFile);
+      displayResultsPage();
     }
   });
+
+  if (fileSelect) {
+    fileSelect.addEventListener("change", () => {
+      selectedFile = fileSelect.value;
+      applyFilters();
+    });
+  }
+
+  if (missingBtn) {
+    missingBtn.addEventListener("click", toggleMissingFilter);
+  }
 });
 
 function toggleInstructions() {


### PR DESCRIPTION
## Summary
- add dropdown to filter results by file
- add button to toggle view of missing files only
- style filter button
- implement filtering logic in script

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68761b098a9883248edd6b9a43f57fd6